### PR TITLE
Fix toggle buttons not responding after interacting with preview iframe

### DIFF
--- a/src/app/__tests__/main-content.test.tsx
+++ b/src/app/__tests__/main-content.test.tsx
@@ -1,0 +1,129 @@
+import { test, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { MainContent } from "@/app/main-content";
+
+// Mock child components to isolate toggle button behavior
+vi.mock("@/lib/contexts/file-system-context", () => ({
+  FileSystemProvider: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  useFileSystem: vi.fn(() => ({
+    fileSystem: {},
+    selectedFile: null,
+    setSelectedFile: vi.fn(),
+    getAllFiles: vi.fn(() => new Map()),
+    refreshTrigger: 0,
+    handleToolCall: vi.fn(),
+    reset: vi.fn(),
+  })),
+}));
+
+vi.mock("@/lib/contexts/chat-context", () => ({
+  ChatProvider: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  useChat: vi.fn(() => ({
+    messages: [],
+    input: "",
+    handleInputChange: vi.fn(),
+    handleSubmit: vi.fn(),
+    status: "idle",
+  })),
+}));
+
+vi.mock("@/components/chat/ChatInterface", () => ({
+  ChatInterface: () => <div data-testid="chat-interface">Chat</div>,
+}));
+
+vi.mock("@/components/preview/PreviewFrame", () => ({
+  PreviewFrame: () => <div data-testid="preview-frame">Preview</div>,
+}));
+
+vi.mock("@/components/editor/FileTree", () => ({
+  FileTree: () => <div data-testid="file-tree">FileTree</div>,
+}));
+
+vi.mock("@/components/editor/CodeEditor", () => ({
+  CodeEditor: () => <div data-testid="code-editor">CodeEditor</div>,
+}));
+
+vi.mock("@/components/HeaderActions", () => ({
+  HeaderActions: () => <div data-testid="header-actions">HeaderActions</div>,
+}));
+
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  ResizablePanel: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizableHandle: () => <div />,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+test("renders Preview tab as active by default", () => {
+  render(<MainContent />);
+  const previewTab = screen.getByRole("tab", { name: "Preview" });
+  expect(previewTab).toHaveAttribute("data-state", "active");
+});
+
+test("shows PreviewFrame by default", () => {
+  render(<MainContent />);
+  expect(screen.getByTestId("preview-frame")).toBeDefined();
+  expect(screen.queryByTestId("code-editor")).toBeNull();
+});
+
+test("switches to Code view when Code tab is clicked", () => {
+  render(<MainContent />);
+  const codeTab = screen.getByRole("tab", { name: "Code" });
+  fireEvent.click(codeTab);
+  expect(screen.getByTestId("code-editor")).toBeDefined();
+  expect(screen.queryByTestId("preview-frame")).toBeNull();
+});
+
+test("switches back to Preview view when Preview tab is clicked", () => {
+  render(<MainContent />);
+
+  // Switch to code first
+  fireEvent.click(screen.getByRole("tab", { name: "Code" }));
+  expect(screen.getByTestId("code-editor")).toBeDefined();
+
+  // Switch back to preview
+  fireEvent.click(screen.getByRole("tab", { name: "Preview" }));
+  expect(screen.getByTestId("preview-frame")).toBeDefined();
+  expect(screen.queryByTestId("code-editor")).toBeNull();
+});
+
+test("blurs iframe on pointerDown in header bar to prevent focus stealing", () => {
+  render(<MainContent />);
+
+  // Simulate iframe having focus by setting up the mock
+  const mockIframe = document.createElement("iframe");
+  const blurSpy = vi.spyOn(mockIframe, "blur");
+
+  // Mock document.activeElement to return our mock iframe
+  Object.defineProperty(document, "activeElement", {
+    value: mockIframe,
+    configurable: true,
+  });
+
+  // Fire pointerDown on the header area (where the toggle buttons are)
+  const previewTab = screen.getByRole("tab", { name: "Preview" });
+  const headerBar = previewTab.closest(".h-14");
+  expect(headerBar).not.toBeNull();
+
+  fireEvent.pointerDown(headerBar!);
+
+  expect(blurSpy).toHaveBeenCalled();
+
+  // Restore original activeElement
+  Object.defineProperty(document, "activeElement", {
+    value: null,
+    configurable: true,
+  });
+});

--- a/src/app/main-content.tsx
+++ b/src/app/main-content.tsx
@@ -59,7 +59,14 @@ export function MainContent({ user, project }: MainContentProps) {
             <ResizablePanel defaultSize={65}>
               <div className="h-full flex flex-col bg-white">
                 {/* Top Bar */}
-                <div className="h-14 border-b border-neutral-200/60 px-6 flex items-center justify-between bg-neutral-50/50">
+                <div
+                  className="h-14 border-b border-neutral-200/60 px-6 flex items-center justify-between bg-neutral-50/50"
+                  onPointerDown={() => {
+                    if (document.activeElement instanceof HTMLIFrameElement) {
+                      document.activeElement.blur();
+                    }
+                  }}
+                >
                   <Tabs
                     value={activeView}
                     onValueChange={(v) =>


### PR DESCRIPTION
Fixes #2

When the preview iframe received focus from user interaction, the first click on the Preview/Code toggle buttons would only transfer focus away from the iframe without registering the click.

Fix by adding a pointerDown handler on the header bar that blurs the iframe before click fires.

Generated with [Claude Code](https://claude.ai/code)